### PR TITLE
Hide forms from Alt-Tab switcher

### DIFF
--- a/src/FormButtonHitter.cs
+++ b/src/FormButtonHitter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -14,6 +14,18 @@ namespace gInk
 	{
 		Root Root;
 		FormCollection FC;
+
+		// http://www.csharp411.com/hide-form-from-alttab/
+		protected override CreateParams CreateParams
+		{
+			get
+			{
+				CreateParams cp = base.CreateParams;
+				// turn on WS_EX_TOOLWINDOW style bit
+				cp.ExStyle |= 0x80;
+				return cp;
+			}
+		}
 
 		public FormButtonHitter(Root root)
 		{

--- a/src/FormCollection.cs
+++ b/src/FormCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -31,6 +31,18 @@ namespace gInk
 		public int gpButtonsLeft, gpButtonsTop, gpButtonsWidth; // the default location, fixed
 
 		public bool gpPenWidth_MouseOn = false;
+
+		// http://www.csharp411.com/hide-form-from-alttab/
+		protected override CreateParams CreateParams
+		{
+			get
+			{
+				CreateParams cp = base.CreateParams;
+				// turn on WS_EX_TOOLWINDOW style bit
+				cp.ExStyle |= 0x80;
+				return cp;
+			}
+		}
 
 		public FormCollection(Root root)
 		{

--- a/src/FormDisplay.cs
+++ b/src/FormDisplay.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -31,6 +31,18 @@ namespace gInk
 
 		byte[] screenbits;
 		byte[] lastscreenbits;
+
+		// http://www.csharp411.com/hide-form-from-alttab/
+		protected override CreateParams CreateParams
+		{
+			get
+			{
+				CreateParams cp = base.CreateParams;
+				// turn on WS_EX_TOOLWINDOW style bit
+				cp.ExStyle |= 0x80;
+				return cp;
+			}
+		}
 
 		public FormDisplay(Root root)
 		{


### PR DESCRIPTION
I've noticed that when alt-tabbing when gInk is being used empty "Form" windows show up in the task-switcher. I've managed to fix it, I think your intention was to hide them completely I guess. This is where I've found how to do it: http://www.csharp411.com/hide-form-from-alttab/

Also, I've just duplicated the property override in both class, because if I used a common base class (which contains the override) Visual Studio couldn't load the designer view of the forms ... I guess this isn't big of a deal, but ... whatever. It's your choice to decide :D